### PR TITLE
PSEC-2920 handle resource-specific permissions correctly

### DIFF
--- a/policyexplorer/policy.py
+++ b/policyexplorer/policy.py
@@ -29,13 +29,9 @@ class Policy:
     def allowed_principals(self, action: str) -> Set[Principal]:
         principals = set()
 
-        resources = self.get_all_resources()
-
-        if not resources:
-            resources = {"*"}
-
-        for resource in resources:
-            principals.update(self.allowed_principals_by_resource(action=action, resource=resource))
+        for principal in self.permission_table.table.keys():
+            if self.permission_table.is_principal_allowed_action(principal=principal, action=action, resource="*"):
+                principals.add(principal)
 
         return principals
 

--- a/policyexplorer/policy.py
+++ b/policyexplorer/policy.py
@@ -27,7 +27,17 @@ class Policy:
 
     # Given an action, get principals that are allowed the action
     def allowed_principals(self, action: str) -> Set[Principal]:
-        return self.allowed_principals_by_resource(action=action, resource="*")
+        principals = set()
+
+        resources = self.get_all_resources()
+
+        if not resources:
+            resources = {"*"}
+
+        for resource in resources:
+            principals.update(self.allowed_principals_by_resource(action=action, resource=resource))
+
+        return principals
 
     # Given an action and a resource, get principals that are allowed the action on the resource
     def allowed_principals_by_resource(self, action: str, resource: str) -> Set[Principal]:

--- a/policyexplorer/policy.py
+++ b/policyexplorer/policy.py
@@ -28,7 +28,6 @@ class Policy:
     # Given an action, get principals that are allowed the action
     def allowed_principals(self, action: str) -> Set[Principal]:
         principals = set()
-
         for principal in self.permission_table.table.keys():
             if self.permission_table.is_principal_allowed_action(principal=principal, action=action, resource="*"):
                 principals.add(principal)


### PR DESCRIPTION
- Fixes issue where roles with kms:ScheduleKeyDeletion were not being picked up
- Caused by resource matching logic relying on "*"