### PR TITLE
PSEC-2920 fix wildcard matching

### DIFF
--- a/policyexplorer/common.py
+++ b/policyexplorer/common.py
@@ -11,7 +11,9 @@ def ensure_array(element: str | List[str]) -> List[str]:
 
 def pattern_to_regex(wildcard: str) -> str:
     # TODO: need to handle "?" too esp when there are more than 1 "?"
-    return ".*".join(wildcard.split("*")) + "$"
+    escaped = re.escape(wildcard)
+    escaped = escaped.replace(r"\*", ".*")
+    return f"^{escaped}$"
 
 
 def matches_pattern(pattern: str, string: str) -> bool:


### PR DESCRIPTION
- Fix wildcard handling in pattern_to_regex to correctly escape regex special characters before converting * into .*.

- This resolves false negatives in permission evaluation for KMS policies (e.g. kms:ScheduleKeyDeletion), where valid resource patterns were not matching correctly.